### PR TITLE
request READ_EXTERNAL_STORAGE permission, better readable timespans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .externalNativeBuild
 .idea
 *.apk
+gitCredentials.json

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="sreich.countthedays">
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+
     <application
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/sreich/countthedays/DayCounterAdapter.kt
+++ b/app/src/main/java/sreich/countthedays/DayCounterAdapter.kt
@@ -44,7 +44,6 @@ class DayCounterAdapter(context: Context) : RecyclerView.Adapter<DayViewHolder>(
             nameTextView.text = counter.name
 
             val dateTime = counter.dateTime
-
             val period = Period(dateTime, DateTime.now(), PeriodType.yearMonthDay())
 
             dateTextView.text = dateViewText(period)
@@ -52,9 +51,14 @@ class DayCounterAdapter(context: Context) : RecyclerView.Adapter<DayViewHolder>(
 
         //todo this needs redone, but it works for now..
         fun dateViewText(period: Period): String {
-            val years = period.years
-            val months = period.months
-            val days = period.days
+            // Negative timespan means the date is in the future
+            val future = period.years < 0 || period.months < 0 || period.days < 0
+
+            // Remove the negative sign
+            // TODO: Use builtin math function to calculate absolute value
+            val years = if(period.years < 0) {-1*period.years} else {period.years}
+            val months = if(period.months < 0) {-1*period.months} else {period.months}
+            val days = if(period.days < 0) {-1*period.days} else {period.days}
 
             val yearsString = when {
                 years == 1 -> "$years year, "
@@ -73,10 +77,23 @@ class DayCounterAdapter(context: Context) : RecyclerView.Adapter<DayViewHolder>(
                 days > 0 || days < 0 -> "$days days"
                 else -> ""
             }
+
+            // Hacky solution to calculate the total amount of days
+            // TODO: Use buildin functions in order to calculate the exact day-difference
+            var totalDays = ( 365 * years + 30 * months + days )
+
             val finalDateText = if (days == 0 && months == 0 && years == 0) {
                 "now"
             } else {
-                "$yearsString$monthsString$daysString"
+                // Build the displayed string
+                if (future == true) {
+                    // The date is in the future
+                    "in $yearsString$monthsString$daysString (~$totalDays days)"
+                }
+                else {
+                    // The date was in the past
+                    "$yearsString$monthsString$daysString ago (~$totalDays days)"
+                }
             }
 
             return finalDateText

--- a/app/src/main/java/sreich/countthedays/SettingsActivity.kt
+++ b/app/src/main/java/sreich/countthedays/SettingsActivity.kt
@@ -153,7 +153,11 @@ class SettingsActivity : AppCompatPreferenceActivity() {
 
         private fun importBackupIntent() {
             val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
-                type = "text/plain"
+                // Using MIME type "text/plain" doesn't let you select the file
+                // Use */* so all files could be selected
+                //type = "text/plain"
+                //type = "application/octet-stream"
+                type = "*/*"
                 addCategory(Intent.CATEGORY_OPENABLE)
             }
 

--- a/app/src/main/java/sreich/countthedays/SettingsActivity.kt
+++ b/app/src/main/java/sreich/countthedays/SettingsActivity.kt
@@ -1,6 +1,7 @@
 package sreich.countthedays
 
 
+import android.Manifest
 import android.annotation.TargetApi
 import android.app.Fragment
 import android.content.ContentResolver
@@ -8,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageItemInfo
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.media.Ringtone
 import android.media.RingtoneManager
@@ -22,6 +24,10 @@ import android.support.v7.app.ActionBar
 import android.preference.PreferenceFragment
 import android.preference.PreferenceManager
 import android.preference.RingtonePreference
+import android.support.annotation.RequiresApi
+import android.support.v4.app.ActivityCompat
+import android.support.v4.app.ActivityCompat.requestPermissions
+import android.support.v4.content.ContextCompat
 import android.support.v4.content.FileProvider
 import android.text.TextUtils
 import android.util.Log
@@ -137,9 +143,29 @@ class SettingsActivity : AppCompatPreferenceActivity() {
 
             val importBackupPref = findPreference(getString(R.string.importBackup))
             importBackupPref.setOnPreferenceClickListener {
-                importBackupIntent()
+                val readPermissionGranted = ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE) ==  PackageManager.PERMISSION_GRANTED;
+                if (readPermissionGranted){
+                    // Everything is good!
+                    // Bring up the file browser
+                    //Log.v(">>>>", "READ Permission GRANTED");
+                    importBackupIntent()
+                }
+                else {
+                    // We do not have reading permission
+                    // Request it
+                    //
+                    // TODO: Implement callback onRequestPermissionsResult (Problem: Higher API-Version is required)
+                    //       Now it is a bit inconvinient for the user, because he has to click the Import Backup button twice
+                    //       The first time he has to grant the reading permission, the second time the file browser opens
+                    // TODO: Inform the user what is happening
+                    //Log.v(">>>>", "READ Permission NOT granted");
+                    val REQUEST_READ = 0;
+                    val test = Manifest.permission.READ_EXTERNAL_STORAGE.toString();
+                    ActivityCompat.requestPermissions(activity, Array(test.length, {test}), REQUEST_READ);
+                }
                 true
             }
+
 
             val exportBackupPref = findPreference(getString(R.string.exportBackup))
             exportBackupPref.setOnPreferenceClickListener {
@@ -149,9 +175,14 @@ class SettingsActivity : AppCompatPreferenceActivity() {
 
         }
 
+
+
+
         private val REQUEST_BACKUP_IMPORT = 1
 
         private fun importBackupIntent() {
+            // Check if we have the reading permission
+
             val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
                 // Using MIME type "text/plain" doesn't let you select the file
                 // Use */* so all files could be selected

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
     <string name="newCounterCancelButton">Cancel</string>
     <string name="newCounterOkButton">OK</string>
     <string name="settingsImportedToast">Settings have been imported</string>
+    <string name="permissionGrantedToast">Reading permission granted! Now you can import your backup</string>
+    <string name="permissionNotGrantedToast">This didn\'t work. Please grant the reading permission!</string>
     <string name="settingsExportNotAvailableToast">There are no settings to export, please create some :)</string>
     <string name="settubgsShareBackupTo">Share backup to...</string>
 </resources>


### PR DESCRIPTION
I tried to implement the permission request.
With my current implementation you need to click "Import Backup" twice (Once to grant the permission and then the second time to open the file browser).
I also tried to make the dates a bit more human readable (eg. display "in x months" instead of "- x months"). This might need some additional fine-tuning.
I also tried to append the total amount of days until the specified date. This is momentarily only a rough calculation and might need to be redone with a proper calendar function. It might also be favourable to make this display style a opt-in in the settings.

Feel free to comment on my changes, in order to improve them.
I have to admit that I never used Kotlin before, so please forgive me for mistakes :)